### PR TITLE
helm chart: updating images/tags w the release (`0.20.0`)

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -7,8 +7,8 @@ debug: false
 
 server:
   image:
-    repository: temporalio/temporal
-    tag: 7b4b09afa0dd516b54c5e0f824d7e5376fc81643
+    repository: temporalio/server
+    tag: 0.20.0
     pullPolicy: IfNotPresent
 
   # Global default settings (can be overridden per service)
@@ -155,7 +155,7 @@ admintools:
   enabled: true
   image:
     repository: temporalio/admin-tools
-    tag: master
+    tag: 0.20.0
     pullPolicy: IfNotPresent
 
   service:
@@ -170,8 +170,8 @@ web:
   replicaCount: 1
 
   image:
-    repository: temporalio/temporal
-    tag: 7b4b09afa0dd516b54c5e0f824d7e5376fc81643
+    repository: temporalio/server
+    tag: 0.20.0
     pullPolicy: IfNotPresent
 
   service:


### PR DESCRIPTION
This change goes together with https://github.com/temporalio/temporal/pull/244

The images of this release are tagged `0.20.0`. Updating helm chart to reference this release's images.

I tested this by deploying to a test k8s cluster and making sure the deployment completed, and that the images that are running is the version that I expect.

Example:

1. install helm chart
```
~/src/temporal-helm-charts $ helm install temporaltest .
NAME: temporaltest
LAST DEPLOYED: Sat Mar 21 15:39:57 2020
NAMESPACE: default
STATUS: deployed
REVISION: 1
NOTES:
To verify that Temporal has started, run:

  kubectl --namespace=default get pods -l "app.kubernetes.io/instance=temporaltest"
```

2. double-check image tags
```
~/src/temporal-helm-charts $ kubectl get pods
NAME                                                    READY   STATUS    RESTARTS   AGE
...
temporaltest-history-657c6d6648-fcf6l                   1/1     Running   2          6m19s
...
```

```
~/src/temporal-helm-charts $ kubectl describe pods/temporaltest-history-657c6d6648-fcf6l | grep "0.20.0"
    Image:          temporalio/server:0.20.0
  Normal   Pulling    12m                kubelet, ip-10-0-3-34.us-west-2.compute.internal  Pulling image "temporalio/server:0.20.0"
  Normal   Pulled     12m                kubelet, ip-10-0-3-34.us-west-2.compute.internal  Successfully pulled image "temporalio/server:0.20.0"
  Normal   Pulled     12m (x2 over 12m)  kubelet, ip-10-0-3-34.us-west-2.compute.internal  Container image "temporalio/server:0.20.0" already present on machine
```


