### PR TITLE
injecting TEMPORAL_CLI_ADDRESS env var into admin tools container

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,16 +60,16 @@ temporaltest-worker-769b996fd-qmvbw                     1/1     Running   2     
 You can also drop into `admin-tools` container via k9s and run Temporal CLI from there:
 
 ```
-bash-5.0# tctl --address ${TEMPORALTEST_FRONTEND_PORT_7233_TCP_ADDR}:${TEMPORALTEST_FRONTEND_PORT_7233_TCP_PORT} --domain nonesuch domain desc
+bash-5.0# tctl --domain nonesuch domain desc
 Error: Domain nonesuch does not exist.
 Error Details: Domain nonesuch does not exist.
 ```
 ```
-bash-5.0# tctl --address ${TEMPORALTEST_FRONTEND_PORT_7233_TCP_ADDR}:${TEMPORALTEST_FRONTEND_PORT_7233_TCP_PORT} --domain nonesuch domain re
+bash-5.0# tctl --domain nonesuch domain re
 Domain nonesuch successfully registered.
 ```
 ```
-bash-5.0# tctl --address ${TEMPORALTEST_FRONTEND_PORT_7233_TCP_ADDR}:${TEMPORALTEST_FRONTEND_PORT_7233_TCP_PORT} --domain nonesuch domain desc
+bash-5.0# tctl --domain nonesuch domain desc
 Name: nonesuch
 UUID: 465bb575-8c01-43f8-a67d-d676e1ae5eae
 Description:

--- a/templates/admintools-deployment.yaml
+++ b/templates/admintools-deployment.yaml
@@ -36,6 +36,9 @@ spec:
             - name: http
               containerPort: 22
               protocol: TCP
+          env:
+            - name: TEMPORAL_CLI_ADDRESS
+              value: {{ .Release.Name }}-frontend:{{ include "temporal.frontend.grpcPort" . }}
           livenessProbe:
               exec:
                 command:


### PR DESCRIPTION
* Adding TEMPORAL_CLI_ADDRESS to admin tools container. (This makes it unnecessary to pass `--address` param to `tctl` tool).
* Updating the readme to reflect the simplified usage.

This change addresses https://github.com/temporalio/temporal-helm-charts/issues/13