### PR TITLE
updating image tags for 0.21.1 release

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -8,7 +8,7 @@ debug: false
 server:
   image:
     repository: temporalio/server
-    tag: 0.20.0
+    tag: 0.21.1
     pullPolicy: IfNotPresent
 
   # Global default settings (can be overridden per service)
@@ -155,65 +155,13 @@ admintools:
   enabled: true
   image:
     repository: temporalio/admin-tools
-    tag: 0.20.0
+    tag: 0.21.1
     pullPolicy: IfNotPresent
 
   service:
     type: ClusterIP
     port: 22
     annotations: {}
-
-
-web:
-  enabled: false
-
-  replicaCount: 1
-
-  image:
-    repository: temporalio/server
-    tag: 0.20.0
-    pullPolicy: IfNotPresent
-
-  service:
-    type: ClusterIP
-    port: 80
-    annotations:
-        enabled: true
-    # loadBalancerIP:
-
-  ingress:
-    enabled: false
-    annotations: {}
-      # kubernetes.io/ingress.class: traefik
-      # ingress.kubernetes.io/ssl-redirect: "false"
-      # traefik.frontend.rule.type: PathPrefix
-    hosts:
-      - "/"
-      # - "domain.com/xyz"
-      # - "domain.com"
-    tls: []
-    #  - secretName: chart-example-tls
-    #    hosts:
-    #      - chart-example.local
-
-
-  resources: {}
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    # limits:
-    #  cpu: 100m
-    #  memory: 128Mi
-    # requests:
-    #  cpu: 100m
-    #  memory: 128Mi
-
-  nodeSelector: {}
-
-  tolerations: []
-
-  affinity: {}
 
 schema:
   setup:


### PR DESCRIPTION
* updating the tags of temporalio/* images for `0.21.1` release,
 * removing unused (for now) section for the web component. 