### PR TITLE
Enable "visibility" by adding and configuring ElasticSearch and Kafka

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -27,7 +27,7 @@ dependencies:
     version: 11.0.4
   - name: elasticsearch
     repository: https://helm.elastic.co
-    version: 7.6.1
+    version: 7.6.2
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -28,6 +28,9 @@ dependencies:
   - name: elasticsearch
     repository: https://helm.elastic.co
     version: 7.6.2
+  - name: kafka
+    repository: https://charts.bitnami.com/bitnami
+    version: 7.2.9
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -25,6 +25,9 @@ dependencies:
   - name: prometheus
     repository: https://kubernetes-charts.storage.googleapis.com
     version: 11.0.4
+  - name: elasticsearch
+    repository: https://helm.elastic.co
+    version: 7.6.1
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/templates/server-configmap.yaml
+++ b/templates/server-configmap.yaml
@@ -47,8 +47,7 @@ data:
                     scheme: "http"
                     host: "elasticsearch-master-headless:9200"
                 indices:
-                    visibility: temporal-visibility-dev
-
+                    visibility: temporal-visibility
 
     server:
       ringpop:
@@ -58,7 +57,6 @@ data:
 
       pprof:
         port: 7936
-
 
     services:
       frontend:
@@ -113,18 +111,18 @@ data:
         tls:
             enabled: false
         clusters:
-            test:
+            cluster_a:
                 brokers:
                     - temporaltest-kafka-headless:9092
         topics:
-            temporal-visibility-dev:
-                cluster: test
-            temporal-visibility-dev-dlq:
-                cluster: test
+            temporal-visibility:
+                cluster: cluster_a
+            temporal-visibility-dlq:
+                cluster: cluster_a
         applications:
             visibility:
-                topic: temporal-visibility-dev
-                dlq-topic: temporal-visibility-dev-dlq
+                topic: temporal-visibility
+                dlq-topic: temporal-visibility-dlq
 
     clusterMetadata:
       enableGlobalDomain: false

--- a/templates/server-configmap.yaml
+++ b/templates/server-configmap.yaml
@@ -18,6 +18,7 @@ data:
     persistence:
       defaultStore: default
       visibilityStore: visibility
+      advancedVisibilityStore: es-visibility
       numHistoryShards: {{ .Values.server.config.numHistoryShards }}
       datastores:
         default:
@@ -40,6 +41,14 @@ data:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
+        es-visibility:
+            elasticsearch:
+                url:
+                    scheme: "http"
+                    host: "elasticsearch-master-headless:9200"
+                indices:
+                    visibility: temporal-visibility-dev
+
 
     server:
       ringpop:
@@ -99,6 +108,23 @@ data:
           prometheus:
             timerType: {{ default .Values.server.metrics.prometheus.timerType .Values.server.worker.metrics.prometheus.timerType }}
             listenAddress: "0.0.0.0:9090"
+
+    kafka:
+        tls:
+            enabled: false
+        clusters:
+            test:
+                brokers:
+                    - temporaltest-kafka-headless:9092
+        topics:
+            temporal-visibility-dev:
+                cluster: test
+            temporal-visibility-dev-dlq:
+                cluster: test
+        applications:
+            visibility:
+                topic: temporal-visibility-dev
+                dlq-topic: temporal-visibility-dev-dlq
 
     clusterMetadata:
       enableGlobalDomain: false

--- a/templates/server-configmap.yaml
+++ b/templates/server-configmap.yaml
@@ -47,7 +47,8 @@ data:
                     scheme: "http"
                     host: "elasticsearch-master-headless:9200"
                 indices:
-                    visibility: temporal-visibility
+                    visibility: temporal-visibility-dev
+
 
     server:
       ringpop:
@@ -57,6 +58,7 @@ data:
 
       pprof:
         port: 7936
+
 
     services:
       frontend:
@@ -111,18 +113,18 @@ data:
         tls:
             enabled: false
         clusters:
-            cluster_a:
+            test:
                 brokers:
                     - temporaltest-kafka-headless:9092
         topics:
-            temporal-visibility:
-                cluster: cluster_a
-            temporal-visibility-dlq:
-                cluster: cluster_a
+            temporal-visibility-dev:
+                cluster: test
+            temporal-visibility-dev-dlq:
+                cluster: test
         applications:
             visibility:
-                topic: temporal-visibility
-                dlq-topic: temporal-visibility-dlq
+                topic: temporal-visibility-dev
+                dlq-topic: temporal-visibility-dev-dlq
 
     clusterMetadata:
       enableGlobalDomain: false

--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -70,6 +70,10 @@ spec:
                   fieldPath: status.podIP
             - name: ENABLE_ES
               value: "true"
+            - name: ES_SEEDS
+              value: elasticsearch-master-headless
+            - name: ES_PORT
+              value: "9200"
             - name: SERVICES
               value: {{ $service }}
             - name: TEMPORAL_STORE_PASSWORD

--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -68,6 +68,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: ENABLE_ES
+              value: "true"
             - name: SERVICES
               value: {{ $service }}
             - name: TEMPORAL_STORE_PASSWORD

--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -74,10 +74,6 @@ spec:
               value: elasticsearch-master-headless
             - name: ES_PORT
               value: "9200"
-            - name: DEFAULT_NAMESPACE
-              value: default
-            - name: DEFAULT_NAMESPACE_RETENTION
-              value: "1"
             - name: SERVICES
               value: {{ $service }}
             - name: TEMPORAL_STORE_PASSWORD

--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -74,6 +74,10 @@ spec:
               value: elasticsearch-master-headless
             - name: ES_PORT
               value: "9200"
+            - name: DEFAULT_NAMESPACE
+              value: default
+            - name: DEFAULT_NAMESPACE_RETENTION
+              value: "1"
             - name: SERVICES
               value: {{ $service }}
             - name: TEMPORAL_STORE_PASSWORD

--- a/values.yaml
+++ b/values.yaml
@@ -8,7 +8,7 @@ debug: false
 server:
   image:
     repository: temporalio/server
-    tag: 0.20.0
+    tag: 0.21.1
     pullPolicy: IfNotPresent
 
   # Global default settings (can be overridden per service)
@@ -155,7 +155,7 @@ admintools:
   enabled: true
   image:
     repository: temporalio/admin-tools
-    tag: 0.20.0
+    tag: 0.21.1
     pullPolicy: IfNotPresent
 
   service:
@@ -171,7 +171,7 @@ web:
 
   image:
     repository: temporalio/server
-    tag: 0.20.0
+    tag: 0.21.1
     pullPolicy: IfNotPresent
 
   service:

--- a/values.yaml
+++ b/values.yaml
@@ -175,6 +175,7 @@ elasticsearch:
   replicas: 3
   persistence:
     enabled: false
+  imageTag: 6.8.8
 
 prometheus:
   nodeExporter:

--- a/values.yaml
+++ b/values.yaml
@@ -224,6 +224,8 @@ schema:
 
 elasticsearch:
   replicas: 3
+  persistence:
+    enabled: false
 
 prometheus:
   nodeExporter:


### PR DESCRIPTION
Adding ElasticSearch and Kafka, and corresponding configs, to enable temporal Visibility features.

Test:

```
$ kubectl exec -it services/temporaltest-admintools -- bash -c 'tctl --ns benchtest wf start --tl samples_tl --wt basic-driver --wid NU4l --dt 5 --et 259200 --wrp 1 --if ./test.json'
Started Workflow Id: NU4l, run Id: 7ec9d5fb-1ff4-4c53-b118-0aa014e50e81
...
$ kubectl exec -it services/temporaltest-admintools -- bash -c 'tctl --ns benchtest wf count'
2
$ kubectl exec -it services/temporaltest-admintools -- bash -c 'tctl --ns benchtest wf scan'
  WORKFLOW TYPE |             WORKFLOW ID              |                RUN ID                | START TIME | EXECUTION TIME | END TIME  
  basic-driver  | NU4l                                 | 7ec9d5fb-1ff4-4c53-b118-0aa014e50e81 | 07:38:57   | 07:38:57       | 07:38:58  
  basicWorkflow | 737713ef-e766-4660-ad47-7cd792bc5937 | b848d9c0-6ebb-4bd8-8c6d-27875c04be51 | 07:38:58   | 07:38:58       | 07:38:58  
$ kubectl exec -it services/temporaltest-admintools -- bash -c 'tctl --ns benchtest wf list'
  WORKFLOW TYPE |             WORKFLOW ID              |                RUN ID                | START TIME | EXECUTION TIME | END TIME  
  basicWorkflow | 737713ef-e766-4660-ad47-7cd792bc5937 | b848d9c0-6ebb-4bd8-8c6d-27875c04be51 | 07:38:58   | 07:38:58       | 07:38:58  
  basic-driver  | NU4l                                 | 7ec9d5fb-1ff4-4c53-b118-0aa014e50e81 | 07:38:57   | 07:38:57       | 07:38:58   
```