### PR TITLE
Remove hardcoded release name from kafka configs

### DIFF
--- a/templates/server-configmap.yaml
+++ b/templates/server-configmap.yaml
@@ -142,7 +142,7 @@ data:
         clusters:
             test:
                 brokers:
-                    - temporaltest-kafka-headless:9092
+                    - {{ .Release.Name }}-kafka-headless:9092
         topics:
             temporal-visibility-dev:
                 cluster: test


### PR DESCRIPTION
Replacing hardcoded reference to release name with `{{ .Release.Name }}`, allowing for release names other than "temporaltest". 

(This fixes #24)

(Verified this by successfully installing a new release, named `temporaltest2`)