### PR TITLE
Update configs: 'server.ringpop' => 'global.membership'

### DIFF
--- a/templates/server-configmap.yaml
+++ b/templates/server-configmap.yaml
@@ -77,8 +77,8 @@ data:
                     visibility: temporal-visibility-dev
 
 
-    server:
-      ringpop:
+    global:
+      membership:
         name: temporal
         maxJoinDuration: 30s
         broadcastAddress: {{ `{{ default .Env.POD_IP "0.0.0.0" }}` }}


### PR DESCRIPTION
Updating configs generated by helm chart to reflect what is required by temporal services (as of https://github.com/temporalio/temporal/pull/354).

tested to make sure deployments succeed and instance starts up as expected:

```

◉ 23:16:17 [markmark ~/src/temporal-helm-charts] (globalmembership|u) $ helm install temporaltest --set server.image.tag=442819414f639f539228f2217d0465f153d0bbe4 --set server.image.repository=markmark206/server --set admintools.image.tag=442819414f639f539228f2217d0465f153d0bbe4 --set admintools.image.repository=markmark206/admin-tools .
NAME: temporaltest
LAST DEPLOYED: Mon May 11 23:16:20 2020
NAMESPACE: default
STATUS: deployed
REVISION: 1
NOTES:
To verify that Temporal has started, run:

  kubectl --namespace=default get pods -l "app.kubernetes.io/instance=temporaltest"
...
◉ 23:21:44 [markmark ~/src/temporal-helm-charts] (globalmembership|u) $ kubectl get pods
NAME                                                    READY   STATUS    RESTARTS   AGE
elasticsearch-master-0                                  1/1     Running   0          11m
elasticsearch-master-1                                  1/1     Running   0          11m
elasticsearch-master-2                                  1/1     Running   0          11m
temporaltest-admintools-64f98658-bgrkg                  1/1     Running   0          11m
temporaltest-cassandra-0                                1/1     Running   0          11m
temporaltest-cassandra-1                                1/1     Running   0          9m12s
temporaltest-cassandra-2                                1/1     Running   0          7m15s
temporaltest-frontend-697c8bf6b9-wl22x                  1/1     Running   2          11m
temporaltest-grafana-578676b454-tmrb9                   1/1     Running   0          11m
temporaltest-history-86588f58fb-h4vz2                   1/1     Running   2          11m
temporaltest-kafka-0                                    1/1     Running   0          11m
temporaltest-kube-state-metrics-df5b9b458-r2dqg         1/1     Running   0          11m
temporaltest-matching-9dd78f946-2hw24                   1/1     Running   2          11m
temporaltest-prometheus-alertmanager-69bb86c55f-n9xcq   2/2     Running   0          11m
temporaltest-prometheus-pushgateway-6d4644b598-8p2qp    1/1     Running   0          11m
temporaltest-prometheus-server-56794d7fc4-pmjcl         2/2     Running   0          11m
temporaltest-worker-579957cb57-6p88n                    1/1     Running   2          11m
temporaltest-zookeeper-0                                1/1     Running   0          11m
```