### PR TITLE
Install elastic search by default

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -242,7 +242,7 @@ schema:
     backoffLimit: 100
 
 elasticsearch:
-  enabled: false
+  enabled: true
   replicas: 3
   persistence:
     enabled: false


### PR DESCRIPTION
In our current "everything is included" setup, we rely on elastic search for visibility functionality. So re-enabling elasticsearch deployment / configuration by default.