### PR TITLE
Existing cassandra

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -23,16 +23,16 @@ dependencies:
     version: 0.15.1
     repository: https://kubernetes-charts-incubator.storage.googleapis.com/
     condition: cassandra.enabled
-  - name: prometheus
-    repository: https://kubernetes-charts.storage.googleapis.com
-    version: 11.0.4
+  - name: kafka
+    repository: https://charts.bitnami.com/bitnami
+    version: 7.2.9
   - name: elasticsearch
     repository: https://helm.elastic.co
     version: 7.6.2
     condition: elasticsearch.enabled
-  - name: kafka
-    repository: https://charts.bitnami.com/bitnami
-    version: 7.2.9
+  - name: prometheus
+    repository: https://kubernetes-charts.storage.googleapis.com
+    version: 11.0.4
   - name: grafana
     repository: https://kubernetes-charts.storage.googleapis.com
     version: 5.0.10

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -22,7 +22,6 @@ dependencies:
   - name: cassandra
     version: 0.15.1
     repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-    enabled: false
     condition: cassandra.enabled
   - name: prometheus
     repository: https://kubernetes-charts.storage.googleapis.com

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -16,11 +16,11 @@ maintainers:
     url: https://temporal.io/
 
 sources:
-        - https://github.com/temporalio/temporal
+  - https://github.com/temporalio/temporal
 
 dependencies:
   - name: cassandra
-    version: "0.14.3"
+    version: 0.15.1
     repository: https://kubernetes-charts-incubator.storage.googleapis.com/
     enabled: false
     condition: cassandra.enabled

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ To install Temporal with all of its dependencies, including Cassandra and Elasti
 ~/temporal-helm$ helm install temporaltest . --timeout 900s
 ```
 
+#### Install using an existing Cassandra Cluster
+
+You can use an existing Cassandra cluster instead of installing one.
+```bash
+~/temporal-helm$ helm install -f values/values.cassandra.yaml temporaltest .
+```
+
 #### MySQL (installed separately)
 
 You may already have a MySQL installation that you want to use with Temporal.

--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -40,22 +40,22 @@ spec:
         {{- end }}
     spec:
       initContainers:
-        {{- if $.Values.cassandra.enabled }}
+        {{- if eq (include "temporal.persistence.driver" (list $ "default")) "cassandra" }}
         - name: check-cassandra-service
           image: busybox
-          command: ['sh', '-c', 'until nslookup {{ include "cassandra.host" $ }}; do echo waiting for cassandra service; sleep 1; done;']
+          command: ['sh', '-c', 'until nslookup {{ include "temporal.persistence.cassandra.hosts" (list $ "default") }}; do echo waiting for cassandra service; sleep 1; done;']
         - name: check-cassandra
           image: "{{ $.Values.cassandra.image.repo }}:{{ $.Values.cassandra.image.tag }}"
           imagePullPolicy: {{ $.Values.cassandra.image.pullPolicy }}
-          command: ['sh', '-c', 'until cqlsh {{ include "cassandra.host" $ }} {{ $.Values.cassandra.config.ports.cql }} -e "SHOW VERSION"; do echo waiting for cassandra to start; sleep 1; done;']
+          command: ['sh', '-c', 'until cqlsh {{ include "temporal.persistence.cassandra.hosts" (list $ "default") }} {{ include "temporal.persistence.cassandra.port" (list $ "default") }} -e "SHOW VERSION"; do echo waiting for cassandra to start; sleep 1; done;']
         - name: check-cassandra-temporal-schema
           image: "{{ $.Values.cassandra.image.repo }}:{{ $.Values.cassandra.image.tag }}"
           imagePullPolicy: {{ $.Values.cassandra.image.pullPolicy }}
-          command: ['sh', '-c', 'until cqlsh {{ include "cassandra.host" $ }} {{ $.Values.cassandra.config.ports.cql }} -e "SELECT keyspace_name FROM system_schema.keyspaces" | grep {{ $.Values.server.config.persistence.default.cassandra.keyspace }}$; do echo waiting for default keyspace to become ready; sleep 1; done;']
+          command: ['sh', '-c', 'until cqlsh {{ include "temporal.persistence.cassandra.hosts" (list $ "default") }} {{ include "temporal.persistence.cassandra.port" (list $ "default") }} -e "SELECT keyspace_name FROM system_schema.keyspaces" | grep {{ $.Values.server.config.persistence.default.cassandra.keyspace }}$; do echo waiting for default keyspace to become ready; sleep 1; done;']
         - name: check-cassandra-visibility-schema
           image: "{{ $.Values.cassandra.image.repo }}:{{ $.Values.cassandra.image.tag }}"
           imagePullPolicy: {{ $.Values.cassandra.image.pullPolicy }}
-          command: ['sh', '-c', 'until cqlsh {{ include "cassandra.host" $ }} {{ $.Values.cassandra.config.ports.cql }} -e "SELECT keyspace_name FROM system_schema.keyspaces" | grep {{ $.Values.server.config.persistence.visibility.cassandra.keyspace }}$; do echo waiting for visibility keyspace to become ready; sleep 1; done;']
+          command: ['sh', '-c', 'until cqlsh {{ include "temporal.persistence.cassandra.hosts" (list $ "default") }} {{ include "temporal.persistence.cassandra.port" (list $ "default") }} -e "SELECT keyspace_name FROM system_schema.keyspaces" | grep {{ $.Values.server.config.persistence.visibility.cassandra.keyspace }}$; do echo waiting for visibility keyspace to become ready; sleep 1; done;']
         {{- else }}
           []
         {{- end }}

--- a/templates/server-job.yaml
+++ b/templates/server-job.yaml
@@ -37,15 +37,14 @@ spec:
     spec:
       restartPolicy: "OnFailure"
       initContainers:
-        {{- if or .Values.cassandra.enabled }}
-        {{- if .Values.cassandra.enabled }}
+        {{- if eq (include "temporal.persistence.driver" (list $ "default")) "cassandra" }}
         - name: check-cassandra-service
           image: busybox
-          command: ['sh', '-c', 'until nslookup {{ include "cassandra.host" $ }}; do echo waiting for cassandra service; sleep 1; done;']
+          command: ['sh', '-c', 'until nslookup {{ include "temporal.persistence.cassandra.hosts" (list $ "default") }}; do echo waiting for cassandra service; sleep 1; done;']
         - name: check-cassandra
           image: "{{ .Values.cassandra.image.repo }}:{{ .Values.cassandra.image.tag }}"
           imagePullPolicy: {{ .Values.cassandra.image.pullPolicy }}
-          command: ['sh', '-c', 'until cqlsh {{ include "cassandra.host" $ }} {{ .Values.cassandra.config.ports.cql }} -e "SHOW VERSION"; do echo waiting for cassandra to start; sleep 1; done;']
+          command: ['sh', '-c', 'until cqlsh {{ include "temporal.persistence.cassandra.hosts" (list $ "default") }} {{ include "temporal.persistence.cassandra.port" (list $ "default") }} -e "SHOW VERSION"; do echo waiting for cassandra to start; sleep 1; done;']
         {{- end }}
         {{- range $store := (list "default" "visibility") }}
         {{- $storeConfig := index $.Values.server.config.persistence $store }}
@@ -72,7 +71,6 @@ spec:
               value: {{ $storeConfig.cassandra.password }}
             {{- end }}
             {{- end }}
-        {{- end }}
         {{- else }}
           []
         {{- end }}
@@ -147,14 +145,14 @@ spec:
     spec:
       restartPolicy: "OnFailure"
       initContainers:
-        {{- if .Values.cassandra.enabled }}
+        {{- if eq (include "temporal.persistence.driver" (list $ "default")) "cassandra" }}
         - name: check-cassandra-service
           image: busybox
-          command: ['sh', '-c', 'until nslookup {{ include "cassandra.host" $ }}; do echo waiting for cassandra service; sleep 1; done;']
+          command: ['sh', '-c', 'until nslookup {{ include "temporal.persistence.cassandra.hosts" (list $ "default") }}; do echo waiting for cassandra service; sleep 1; done;']
         - name: check-cassandra
           image: "{{ .Values.cassandra.image.repo }}:{{ .Values.cassandra.image.tag }}"
           imagePullPolicy: {{ .Values.cassandra.image.pullPolicy }}
-          command: ['sh', '-c', 'until cqlsh {{ include "cassandra.host" $ }} {{ .Values.cassandra.config.ports.cql }} -e "SHOW VERSION"; do echo waiting for cassandra to start; sleep 1; done;']
+          command: ['sh', '-c', 'until cqlsh {{ include "temporal.persistence.cassandra.hosts" (list $ "default") }} {{ include "temporal.persistence.cassandra.port" (list $ "default") }} -e "SHOW VERSION"; do echo waiting for cassandra to start; sleep 1; done;']
         {{- else }}
           []
         {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -246,7 +246,29 @@ elasticsearch:
   replicas: 3
   persistence:
     enabled: false
-  imageTag: 6.8.8
+  imageTag: 7.7.0
+  # Permit co-located instances for solitary minikube virtual machines.
+  antiAffinity: soft
+
+  # Shrink default JVM heap.
+  esJavaOpts: "-Xmx128m -Xms128m"
+
+  # Allocate smaller chunks of memory per pod.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512M
+    limits:
+      cpu: 1000m
+      memory: 512M
+
+  # Request smaller persistent volumes.
+  volumeClaimTemplate:
+    accessModes: [ "ReadWriteOnce" ]
+    storageClassName: "standard"
+    resources:
+      requests:
+        storage: 100M
 
 prometheus:
   nodeExporter:
@@ -267,7 +289,7 @@ cassandra:
     enabled: false
   image:
     repo: cassandra
-    tag: 3.11.3
+    tag: 3.11.6
     pullPolicy: IfNotPresent
   config:
     cluster_size: 3
@@ -277,6 +299,13 @@ cassandra:
     max_heap_size: 512M
     heap_new_size: 128M
     seed_size: 0
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512M
+    limits:
+      cpu: 1000m
+      memory: 512M
   service:
     type: ClusterIP
 

--- a/values.yaml
+++ b/values.yaml
@@ -26,8 +26,7 @@ server:
     prometheus:
       timerType: histogram
   podAnnotations: {}
-  resources:
-    {}
+  resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -56,8 +55,8 @@ server:
           hosts: []
           # port: 9042
           keyspace: temporal
-          user: "user"
-          password: "password"
+          user: ""
+          password: ""
           existingSecret: ""
           consistency: One
           # datacenter: "us-east-1a"
@@ -81,8 +80,8 @@ server:
           hosts: []
           # port: 9042
           keyspace: temporal_visibility
-          user: "user"
-          password: "password"
+          user: ""
+          password: ""
           existingSecret: ""
           consistency: One
           # datacenter: "us-east-1a"
@@ -214,7 +213,6 @@ web:
     #    hosts:
     #      - chart-example.local
 
-
   resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
@@ -264,7 +262,7 @@ elasticsearch:
 
   # Request smaller persistent volumes.
   volumeClaimTemplate:
-    accessModes: [ "ReadWriteOnce" ]
+    accessModes: ["ReadWriteOnce"]
     storageClassName: "standard"
     resources:
       requests:

--- a/values/values.cassandra.yaml
+++ b/values/values.cassandra.yaml
@@ -1,0 +1,31 @@
+server:
+  config:
+    persistence:
+      default:
+        driver: "cassandra"
+
+        cassandra:
+          hosts: "cassandra-0.cassandra"
+          port: 9042
+          keyspace: "temporal"
+          consistency: "One"
+
+          # Authentication
+          # user: ""
+          # password: ""
+
+      visibility:
+        driver: "cassandra"
+
+        cassandra:
+          hosts: "cassandra-0.cassandra"
+          port: 9042
+          keyspace: "temporal_visibility"
+          consistency: "One"
+
+          # Authentication
+          # user: ""
+          # password: ""
+
+cassandra:
+  enabled: false


### PR DESCRIPTION
The problem this PR addresses is that `.Values.cassandra.enabled` ends up disabling a lot of the functionality around checking if cassandra is ready, which should be running whether or not Cassandra is existing or created.